### PR TITLE
New business rule for create group

### DIFF
--- a/backend/src/modules/groups/groups.module.ts
+++ b/backend/src/modules/groups/groups.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { GroupsService } from './groups.service';
 import { GroupsController } from './groups.controller';
+import { GroupMembersService } from '../group-members/group-members.service';
 
 @Module({
   controllers: [GroupsController],
-  providers: [GroupsService],
+  providers: [GroupsService, GroupMembersService],
 })
 export class GroupsModule {}

--- a/backend/src/tests/groups/groups.controller.spec.ts
+++ b/backend/src/tests/groups/groups.controller.spec.ts
@@ -1,21 +1,18 @@
-import { prismaMock } from '../prisma-mock';
 import { Test } from '@nestjs/testing';
-import { createGroupInput, group } from './mock/groups.service.mock';
 import { GroupsService } from 'src/modules/groups/groups.service';
 import { GroupsController } from '../../modules/groups/groups.controller';
+import { GroupMembersService } from 'src/modules/group-members/group-members.service';
 
-describe('UserController', () => {
+describe('Groups Controller', () => {
   let controller: GroupsController;
-  let service: GroupsService;
 
   beforeEach(async () => {
     const module = await Test.createTestingModule({
       controllers: [GroupsController],
-      providers: [GroupsService],
+      providers: [GroupsService, GroupMembersService],
     }).compile();
 
     controller = module.get(GroupsController);
-    service = module.get(GroupsService);
   });
 
   it('should be defined', () => {

--- a/backend/src/tests/groups/mock/groups.service.mock.ts
+++ b/backend/src/tests/groups/mock/groups.service.mock.ts
@@ -1,4 +1,5 @@
 import { Group } from '@prisma/client';
+import { generateUUID } from '../../../shared/utils/uuid/generateUUID';
 
 const group: Group = {
   name: 'group1',
@@ -8,14 +9,14 @@ const group: Group = {
   deleted_at: null,
   image_url: '',
   updated_at: new Date(),
-  uuid: '01',
+  uuid: generateUUID(),
 };
 
 const createGroupInput = {
   name: 'group1',
   description: 'description1',
   image_url: '',
-  creator_uuid: '02',
+  creator_uuid: '01',
 };
 
 const updateGroupInput = {


### PR DESCRIPTION
# Implementing Business Rule Changes for Group Creation

## Description:
This pull request (PR) introduces significant changes to the business rules related to groups in the application. The goal is to ensure that when a group is created, a corresponding record is automatically inserted into the "groupMembers" table. This new record will include the UUID of the creator (referred to as "creator_uuid") and assign them the role of "Admin" within the group. The changes were implemented using Test-Driven Development (TDD) practices and integrated into the relevant service.

### Details:

   * Modified group creation logic to include automatic creation of a "groupMembers" record.
   * The "creator_uuid" is extracted from the provided input and associated with the newly created group.
   * The assigned role for the creator in the group is set to "Admin".
   * Implemented unit tests using TDD approach to ensure the correctness and reliability of the new functionality.
   * Integrated the changes seamlessly into the existing service codebase, maintaining code consistency and adhering to coding standards.

### Purpose:
The purpose of this PR is to enhance the group creation process by automating the addition of the creator to the "groupMembers" table with the appropriate role. This simplifies the management of group members and ensures consistent behavior throughout the application. The introduction of TDD guarantees the reliability and maintainability of the implemented changes.